### PR TITLE
Feature/strip spaces from ip address

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
@@ -307,7 +307,13 @@ export const HandleServers = ({ serverId }: Props) => {
 									<FormItem>
 										<FormLabel>{t("settings.terminal.ipAddress")}</FormLabel>
 										<FormControl>
-											<Input placeholder="192.168.1.100" {...field} />
+											<Input 
+											    placeholder="192.168.1.100" 
+											    {...field} 
+											    onChange={(e) => {
+											    	field.onChange(e.target.value.trim());
+											    }}
+											/>
 										</FormControl>
 
 										<FormMessage />

--- a/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
@@ -212,7 +212,13 @@ export const CreateServer = ({ stepper }: Props) => {
 									<FormItem>
 										<FormLabel>IP Address</FormLabel>
 										<FormControl>
-											<Input placeholder="192.168.1.100" {...field} />
+											<Input 
+											    placeholder="192.168.1.100" 
+											    {...field} 
+											    onChange={(e) => {
+											    	field.onChange(e.target.value.trim());
+											    }}
+											/>
 										</FormControl>
 
 										<FormMessage />

--- a/packages/server/src/db/schema/server.ts
+++ b/packages/server/src/db/schema/server.ts
@@ -132,7 +132,11 @@ export const apiCreateServer = createSchema
 		username: true,
 		sshKeyId: true,
 	})
-	.required();
+	.required()
+	.transform((data) => ({
+		...data,
+		ipAddress: data.ipAddress?.trim(),
+	}));
 
 export const apiFindOneServer = createSchema
 	.pick({

--- a/packages/server/src/services/server.ts
+++ b/packages/server/src/services/server.ts
@@ -17,6 +17,7 @@ export const createServer = async (
 		.insert(server)
 		.values({
 			...input,
+			ipAddress: input.ipAddress?.trim(),
 			organizationId: organizationId,
 			createdAt: new Date().toISOString(),
 		})


### PR DESCRIPTION
Fixes #7 

The IP address whitespace issue is addressed by making changes to the following layers of Dokploy:

## Frontend 

`create-server.tsx`:
The `.trim()` method is added to the IP address input field using an `onChange` handler. This is the first layer of defense.

## Backend

`schema/server.ts`:
The `.transform()` method is added to the `apiCreateServer` schema, ensuring that IP input is validated at an API level.

## Service Layer

`services/server.ts`:
The `.trim()` method is used one last time before data is inserted to server, guaranteeing clean data to the database.

## Before:
<img width="1440" height="856" alt="Screenshot 2025-10-05 at 8 04 19 PM" src="https://github.com/user-attachments/assets/f24be3a6-ca36-40a8-8430-465733d1502d" />

## After:
<img width="1440" height="856" alt="Screenshot 2025-10-05 at 8 08 28 PM" src="https://github.com/user-attachments/assets/fce77e55-c53d-440a-b166-045303d01107" />

## Demo Video

https://github.com/user-attachments/assets/afe1dd39-d6ae-44b1-84b1-401c0f8a17af

