### PR TITLE
Fix service to discover cli flags!

### DIFF
--- a/apps/dokploy/__test__/compose/load-services.test.ts
+++ b/apps/dokploy/__test__/compose/load-services.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Test for Milestone 1: Improve Backend Error Handling
+ * 
+ * Tests that loadServices gracefully handles errors instead of throwing,
+ * returning empty arrays to enable UI to show manual input fallback.
+ */
+
+import type { Compose } from "@dokploy/server/db/schema/compose";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Mock database to prevent actual DB connections
+vi.mock("@dokploy/server/db", () => ({
+	db: {
+		query: {
+			compose: {
+				findFirst: vi.fn(),
+			},
+		},
+	},
+}));
+
+// Mock dependencies before importing loadServices
+const mockFindComposeById = vi.fn();
+const mockCloneCompose = vi.fn();
+const mockCloneComposeRemote = vi.fn();
+const mockLoadDockerCompose = vi.fn();
+const mockLoadDockerComposeRemote = vi.fn();
+const mockRandomizeSpecificationFile = vi.fn((data, _suffix) => data);
+
+vi.mock("@dokploy/server/services/compose", async () => {
+	const actual = await vi.importActual("@dokploy/server/services/compose");
+	return {
+		...actual,
+		findComposeById: mockFindComposeById,
+	};
+});
+
+vi.mock("@dokploy/server/utils/docker/domain", () => ({
+	cloneCompose: mockCloneCompose,
+	cloneComposeRemote: mockCloneComposeRemote,
+	loadDockerCompose: mockLoadDockerCompose,
+	loadDockerComposeRemote: mockLoadDockerComposeRemote,
+}));
+
+vi.mock("@dokploy/server/utils/docker/compose", () => ({
+	randomizeSpecificationFile: mockRandomizeSpecificationFile,
+}));
+
+// Import after mocks are set up
+const { loadServices } = await import("@dokploy/server/services/compose");
+
+const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+describe("loadServices - Error Handling (Milestone 1)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleWarnSpy.mockClear();
+	});
+
+	test("should return empty array when services not found", async () => {
+		const mockCompose: Partial<Compose> = {
+			composeId: "test-compose-1",
+			appName: "test-app",
+			serverId: null,
+			randomize: false,
+		};
+
+		mockFindComposeById.mockResolvedValue(mockCompose as Compose);
+		mockCloneCompose.mockResolvedValue(undefined);
+		mockLoadDockerCompose.mockResolvedValue({
+			version: "3.8",
+			// No services property
+		} as any);
+
+		const result = await loadServices("test-compose-1", "cache");
+
+		expect(result).toEqual([]);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			"No services found in compose file for composeId: test-compose-1",
+		);
+	});
+
+	test("should return empty array when composeData is null", async () => {
+		const mockCompose: Partial<Compose> = {
+			composeId: "test-compose-2",
+			appName: "test-app",
+			serverId: null,
+			randomize: false,
+		};
+
+		mockFindComposeById.mockResolvedValue(mockCompose as Compose);
+		mockCloneCompose.mockResolvedValue(undefined);
+		mockLoadDockerCompose.mockResolvedValue(null);
+
+		const result = await loadServices("test-compose-2", "cache");
+
+		expect(result).toEqual([]);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			"No services found in compose file for composeId: test-compose-2",
+		);
+	});
+
+	test("should return empty array on error during file loading", async () => {
+		const mockCompose: Partial<Compose> = {
+			composeId: "test-compose-3",
+			appName: "test-app",
+			serverId: null,
+			randomize: false,
+		};
+
+		mockFindComposeById.mockResolvedValue(mockCompose as Compose);
+		mockCloneCompose.mockResolvedValue(undefined);
+		mockLoadDockerCompose.mockRejectedValue(new Error("File not found"));
+
+		const result = await loadServices("test-compose-3", "cache");
+
+		expect(result).toEqual([]);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			"Error loading services for composeId: test-compose-3",
+			"File not found",
+		);
+	});
+
+	test("should return empty array on error during clone", async () => {
+		const mockCompose: Partial<Compose> = {
+			composeId: "test-compose-4",
+			appName: "test-app",
+			serverId: null,
+			randomize: false,
+		};
+
+		mockFindComposeById.mockResolvedValue(mockCompose as Compose);
+		mockCloneCompose.mockRejectedValue(new Error("Clone failed"));
+
+		const result = await loadServices("test-compose-4", "fetch");
+
+		expect(result).toEqual([]);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			"Error loading services for composeId: test-compose-4",
+			"Clone failed",
+		);
+	});
+
+	test("should return services array when services are found", async () => {
+		const mockCompose: Partial<Compose> = {
+			composeId: "test-compose-5",
+			appName: "test-app",
+			serverId: null,
+			randomize: false,
+		};
+
+		const mockComposeData = {
+			version: "3.8",
+			services: {
+				web: { image: "nginx:latest" },
+				api: { image: "node:latest" },
+			},
+		};
+
+		mockFindComposeById.mockResolvedValue(mockCompose as Compose);
+		mockCloneCompose.mockResolvedValue(undefined);
+		mockLoadDockerCompose.mockResolvedValue(mockComposeData as any);
+
+		const result = await loadServices("test-compose-5", "cache");
+
+		expect(result).toEqual(["web", "api"]);
+		expect(consoleWarnSpy).not.toHaveBeenCalled();
+	});
+
+	test("should work with remote server", async () => {
+		const mockCompose: Partial<Compose> = {
+			composeId: "test-compose-6",
+			appName: "test-app",
+			serverId: "server-123",
+			randomize: false,
+		};
+
+		const mockComposeData = {
+			version: "3.8",
+			services: {
+				web: { image: "nginx:latest" },
+			},
+		};
+
+		mockFindComposeById.mockResolvedValue(mockCompose as Compose);
+		mockCloneComposeRemote.mockResolvedValue(undefined);
+		mockLoadDockerComposeRemote.mockResolvedValue(mockComposeData as any);
+
+		const result = await loadServices("test-compose-6", "fetch");
+
+		expect(result).toEqual(["web"]);
+		expect(consoleWarnSpy).not.toHaveBeenCalled();
+	});
+
+	test("should handle errors gracefully with randomized compose", async () => {
+		const mockCompose: Partial<Compose> = {
+			composeId: "test-compose-7",
+			appName: "test-app",
+			serverId: null,
+			randomize: true,
+			suffix: "test-suffix",
+		};
+
+		mockFindComposeById.mockResolvedValue(mockCompose as Compose);
+		mockCloneCompose.mockResolvedValue(undefined);
+		mockLoadDockerCompose.mockRejectedValue(new Error("Randomize failed"));
+
+		const result = await loadServices("test-compose-7", "cache");
+
+		expect(result).toEqual([]);
+		expect(consoleWarnSpy).toHaveBeenCalled();
+	});
+});
+

--- a/apps/dokploy/__test__/compose/parse-compose-path.test.ts
+++ b/apps/dokploy/__test__/compose/parse-compose-path.test.ts
@@ -175,5 +175,66 @@ describe("getComposePath - CLI Flag Parsing (Milestone 2)", () => {
 
 		expect(result).toBe(expected);
 	});
+
+	test("should handle multiple -f flags and use first", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: "-f docker-compose.yml -f docker-compose.prod.yml",
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "docker-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should handle empty compose path", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: "",
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "./docker-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should handle whitespace-only compose path", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: "   ",
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "./docker-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should handle path with special characters in quotes", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: '-f "path with spaces & special-chars.yml"',
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join(
+			"/mock/compose/path",
+			"test-app",
+			"code",
+			"path with spaces & special-chars.yml",
+		);
+
+		expect(result).toBe(expected);
+	});
 });
 

--- a/apps/dokploy/__test__/compose/parse-compose-path.test.ts
+++ b/apps/dokploy/__test__/compose/parse-compose-path.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Test for Milestone 2: Add CLI Flag Parsing Utility
+ * 
+ * Tests that getComposePath correctly parses CLI flags from composePath
+ * to extract actual file paths.
+ */
+
+import { getComposePath } from "@dokploy/server/utils/docker/domain";
+import type { Compose } from "@dokploy/server/db/schema/compose";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { join } from "node:path";
+
+// Mock paths function - define completely inside factory
+vi.mock("@dokploy/server/constants", () => {
+	return {
+		paths: vi.fn(() => ({
+			COMPOSE_PATH: "/mock/compose/path",
+		})),
+	};
+});
+
+// Get the mocked paths function after import
+import { paths } from "@dokploy/server/constants";
+
+const mockPaths = vi.mocked(paths);
+
+describe("getComposePath - CLI Flag Parsing (Milestone 2)", () => {
+	beforeEach(() => {
+		mockPaths.mockReturnValue({
+			COMPOSE_PATH: "/mock/compose/path",
+		});
+	});
+
+	test("should parse -f flag and extract file path", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: "-f docker-compose.yml",
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "docker-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should parse --file flag and extract file path", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: "--file custom-compose.yml",
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "custom-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should parse -f flag with double-quoted path", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: '-f "my-compose.yml"',
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "my-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should parse -f flag with single-quoted path", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: "-f 'my-compose.yml'",
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "my-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should return simple path as-is when no flags detected", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: "docker-compose.yml",
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "docker-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should not apply parsing for raw source type", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "raw",
+			composePath: "-f should-not-parse.yml",
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		// Raw source type always uses docker-compose.yml, regardless of composePath
+		const expected = join("/mock/compose/path", "test-app", "code", "docker-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should handle whitespace around flags", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: "  -f   docker-compose.yml  ",
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "docker-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should handle path with spaces in filename", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: '-f "my compose file.yml"',
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "my compose file.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should handle --file with quoted path", () => {
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: '--file "custom-path.yml"',
+			serverId: null,
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/mock/compose/path", "test-app", "code", "custom-path.yml");
+
+		expect(result).toBe(expected);
+	});
+
+	test("should work with remote server", () => {
+		mockPaths.mockReturnValue({
+			COMPOSE_PATH: "/remote/compose/path",
+		});
+
+		const mockCompose: Partial<Compose> = {
+			appName: "test-app",
+			sourceType: "github",
+			composePath: "-f docker-compose.yml",
+			serverId: "server-123",
+		};
+
+		const result = getComposePath(mockCompose as Compose);
+		const expected = join("/remote/compose/path", "test-app", "code", "docker-compose.yml");
+
+		expect(result).toBe(expected);
+	});
+});
+

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -39,7 +39,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { DatabaseZap, Dices, RefreshCw } from "lucide-react";
+import { CheckCircle2, DatabaseZap, Dices, RefreshCw } from "lucide-react";
 import Link from "next/link";
 import z from "zod";
 
@@ -279,45 +279,73 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 								<div className="flex flex-row items-end w-full gap-4">
 									{domainType === "compose" && (
 										<div className="flex flex-col gap-2 w-full">
-											{errorServices && (
+											{(errorServices ||
+												(!isLoadingServices &&
+													services !== undefined &&
+													services.length === 0)) && (
 												<AlertBlock
 													type="warning"
 													className="[overflow-wrap:anywhere]"
 												>
-													{errorServices?.message}
+													{errorServices?.message ||
+														"Service discovery couldn't find services. You can enter the service name manually below."}
 												</AlertBlock>
 											)}
 											<FormField
 												control={form.control}
 												name="serviceName"
-												render={({ field }) => (
-													<FormItem className="w-full">
-														<FormLabel>Service Name</FormLabel>
-														<div className="flex gap-2">
-															<Select
-																onValueChange={field.onChange}
-																defaultValue={field.value || ""}
-															>
-																<FormControl>
-																	<SelectTrigger>
-																		<SelectValue placeholder="Select a service name" />
-																	</SelectTrigger>
-																</FormControl>
+												render={({ field }) => {
+													// Check if the current value matches a discovered service
+													const valueMatchesService =
+														field.value &&
+														services?.includes(field.value);
+													const isInSync = valueMatchesService;
 
-																<SelectContent>
-																	{services?.map((service, index) => (
-																		<SelectItem
-																			value={service}
-																			key={`${service}-${index}`}
-																		>
-																			{service}
+													return (
+														<FormItem className="w-full">
+															<FormLabel>Service Name</FormLabel>
+															<div className="flex gap-2">
+																<Select
+																	onValueChange={(value) => {
+																		field.onChange(value);
+																	}}
+																	value={field.value || ""}
+																>
+																	<FormControl>
+																		<SelectTrigger className="flex-1">
+																			<SelectValue placeholder="Select a service name" />
+																		</SelectTrigger>
+																	</FormControl>
+
+																	<SelectContent>
+																		{services?.map((service, index) => (
+																			<SelectItem
+																				value={service}
+																				key={`${service}-${index}`}
+																			>
+																				{service}
+																			</SelectItem>
+																		))}
+																		<SelectItem value="none" disabled>
+																			Empty
 																		</SelectItem>
-																	))}
-																	<SelectItem value="none" disabled>
-																		Empty
-																	</SelectItem>
-																</SelectContent>
-															</Select>
+																	</SelectContent>
+																</Select>
+																<div className="relative flex-1">
+																	<FormControl>
+																		<Input
+																			placeholder="Or enter service name manually"
+																			value={field.value || ""}
+																			onChange={(e) => {
+																				field.onChange(e.target.value);
+																			}}
+																			className="flex-1"
+																		/>
+																	</FormControl>
+																	{isInSync && field.value && (
+																		<CheckCircle2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-green-500" />
+																	)}
+																</div>
 															<TooltipProvider delayDuration={0}>
 																<Tooltip>
 																	<TooltipTrigger asChild>

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -412,8 +412,9 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 
 														<FormMessage />
 													</FormItem>
-												)}
-											/>
+												);
+											}}
+										/>
 										</div>
 									)}
 								</div>

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -148,6 +148,19 @@ export const findComposeById = async (composeId: string) => {
 	return result;
 };
 
+/**
+ * Loads service names from a Docker Compose file
+ * 
+ * @param composeId - The ID of the compose application
+ * @param type - "fetch" to clone repository first, "cache" to use existing files
+ * @returns Array of service names, or empty array on error (allows manual input fallback)
+ * 
+ * @remarks
+ * - Gracefully handles errors by returning empty array instead of throwing
+ * - Logs warnings for debugging purposes
+ * - Supports both local and remote servers
+ * - Handles CLI flags in composePath via getComposePath parsing
+ */
 export const loadServices = async (
 	composeId: string,
 	type: "fetch" | "cache" = "fetch",

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -154,40 +154,47 @@ export const loadServices = async (
 ) => {
 	const compose = await findComposeById(composeId);
 
-	if (type === "fetch") {
-		if (compose.serverId) {
-			await cloneComposeRemote(compose);
-		} else {
-			await cloneCompose(compose);
+	try {
+		if (type === "fetch") {
+			if (compose.serverId) {
+				await cloneComposeRemote(compose);
+			} else {
+				await cloneCompose(compose);
+			}
 		}
-	}
 
-	let composeData: ComposeSpecification | null;
+		let composeData: ComposeSpecification | null;
 
-	if (compose.serverId) {
-		composeData = await loadDockerComposeRemote(compose);
-	} else {
-		composeData = await loadDockerCompose(compose);
-	}
+		if (compose.serverId) {
+			composeData = await loadDockerComposeRemote(compose);
+		} else {
+			composeData = await loadDockerCompose(compose);
+		}
 
-	if (compose.randomize && composeData) {
-		const randomizedCompose = randomizeSpecificationFile(
-			composeData,
-			compose.suffix,
+		if (compose.randomize && composeData) {
+			const randomizedCompose = randomizeSpecificationFile(
+				composeData,
+				compose.suffix,
+			);
+			composeData = randomizedCompose;
+		}
+
+		if (!composeData?.services) {
+			console.warn(
+				`No services found in compose file for composeId: ${composeId}`,
+			);
+			return []; // Return empty array instead of throwing
+		}
+
+		const services = Object.keys(composeData.services);
+		return [...services];
+	} catch (error) {
+		console.warn(
+			`Error loading services for composeId: ${composeId}`,
+			error instanceof Error ? error.message : error,
 		);
-		composeData = randomizedCompose;
+		return []; // Return empty array on error, allow manual input
 	}
-
-	if (!composeData?.services) {
-		throw new TRPCError({
-			code: "NOT_FOUND",
-			message: "Services not found",
-		});
-	}
-
-	const services = Object.keys(composeData.services);
-
-	return [...services];
 };
 
 export const updateCompose = async (

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -74,31 +74,44 @@ export const cloneComposeRemote = async (compose: Compose) => {
 /**
  * Parses composePath to extract actual file path, handling CLI flags
  * Supports: -f file.yml, --file file.yml, -f "quoted path.yml"
+ * Handles edge cases: multiple flags (uses first), whitespace, empty paths
  */
 const parseComposePath = (composePath: string): string => {
+	// Handle empty or whitespace-only paths
+	const trimmed = composePath.trim();
+	if (!trimmed) {
+		return "./docker-compose.yml"; // Default fallback
+	}
+
 	// If no CLI flags detected, return as-is
-	if (!composePath.includes("-f") && !composePath.includes("--file")) {
-		return composePath.trim();
+	if (!trimmed.includes("-f") && !trimmed.includes("--file")) {
+		return trimmed;
 	}
 
 	// Pattern 1: -f file.yml or -f "file.yml" or -f 'file.yml'
+	// Matches first occurrence only (handles multiple -f flags by taking first)
 	const flagPattern = /-f\s+(?:"([^"]+)"|'([^']+)'|(\S+))/;
-	const flagMatch = composePath.match(flagPattern);
+	const flagMatch = trimmed.match(flagPattern);
 	if (flagMatch) {
-		return (flagMatch[1] || flagMatch[2] || flagMatch[3] || "").trim();
+		const extracted = flagMatch[1] || flagMatch[2] || flagMatch[3] || "";
+		const result = extracted.trim();
+		// If extracted path is empty, fall back to default
+		return result || "./docker-compose.yml";
 	}
 
 	// Pattern 2: --file file.yml or --file "file.yml" or --file 'file.yml'
 	const longFlagPattern = /--file\s+(?:"([^"]+)"|'([^']+)'|(\S+))/;
-	const longFlagMatch = composePath.match(longFlagPattern);
+	const longFlagMatch = trimmed.match(longFlagPattern);
 	if (longFlagMatch) {
-		return (
-			longFlagMatch[1] || longFlagMatch[2] || longFlagMatch[3] || ""
-		).trim();
+		const extracted =
+			longFlagMatch[1] || longFlagMatch[2] || longFlagMatch[3] || "";
+		const result = extracted.trim();
+		// If extracted path is empty, fall back to default
+		return result || "./docker-compose.yml";
 	}
 
 	// Fallback: return original (may contain flags, but better than nothing)
-	return composePath.trim();
+	return trimmed;
 };
 
 export const getComposePath = (compose: Compose) => {

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -71,6 +71,36 @@ export const cloneComposeRemote = async (compose: Compose) => {
 	}
 };
 
+/**
+ * Parses composePath to extract actual file path, handling CLI flags
+ * Supports: -f file.yml, --file file.yml, -f "quoted path.yml"
+ */
+const parseComposePath = (composePath: string): string => {
+	// If no CLI flags detected, return as-is
+	if (!composePath.includes("-f") && !composePath.includes("--file")) {
+		return composePath.trim();
+	}
+
+	// Pattern 1: -f file.yml or -f "file.yml" or -f 'file.yml'
+	const flagPattern = /-f\s+(?:"([^"]+)"|'([^']+)'|(\S+))/;
+	const flagMatch = composePath.match(flagPattern);
+	if (flagMatch) {
+		return (flagMatch[1] || flagMatch[2] || flagMatch[3] || "").trim();
+	}
+
+	// Pattern 2: --file file.yml or --file "file.yml" or --file 'file.yml'
+	const longFlagPattern = /--file\s+(?:"([^"]+)"|'([^']+)'|(\S+))/;
+	const longFlagMatch = composePath.match(longFlagPattern);
+	if (longFlagMatch) {
+		return (
+			longFlagMatch[1] || longFlagMatch[2] || longFlagMatch[3] || ""
+		).trim();
+	}
+
+	// Fallback: return original (may contain flags, but better than nothing)
+	return composePath.trim();
+};
+
 export const getComposePath = (compose: Compose) => {
 	const { COMPOSE_PATH } = paths(!!compose.serverId);
 	const { appName, sourceType, composePath } = compose;
@@ -79,7 +109,7 @@ export const getComposePath = (compose: Compose) => {
 	if (sourceType === "raw") {
 		path = "docker-compose.yml";
 	} else {
-		path = composePath;
+		path = parseComposePath(composePath);
 	}
 
 	return join(COMPOSE_PATH, appName, "code", path);


### PR DESCRIPTION
# Problem

When configuring domains for Docker Compose applications, users could specify a compose file path with CLI flags (e.g., `-f docker-compose.yml` or `--file docker-compose.prod.yml`) in the "Compose Path" field. However, the service discovery system failed to parse these CLI flags, resulting in:

- Service discovery failing to find services
- No fallback mechanism for users to manually enter service names
- Poor user experience with unclear error messages

# Solution

This PR implements a comprehensive solution with three key improvements:

1. **CLI Flag Parsing**: Enhanced `parseComposePath` utility function that correctly extracts file paths from compose paths containing CLI flags (`-f`, `--file`) with support for quoted and unquoted paths.

2. **Manual Service Name Input**: Added a manual input field alongside the service dropdown, allowing users to enter service names when automatic discovery fails.

3. **Improved UX**: 
   - Warning messages when service discovery fails
   - Visual feedback (green checkmark) when manually entered service name matches a discovered service
   - Bidirectional synchronization between dropdown and manual input

# Changes Made

- **Backend (`dokploy/packages/server/src/utils/docker/domain.ts`)**:
  - Added `parseComposePath` function to extract file paths from CLI flags
  - Enhanced `getComposePath` to use the new parsing logic
  - Handles edge cases: multiple flags, quoted paths, empty paths, whitespace

- **Backend (`dokploy/packages/server/src/services/compose.ts`)**:
  - Improved error handling in `loadServices` to return empty array instead of throwing (allows manual input fallback)

- **Frontend (`dokploy/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx`)**:
  - Added manual service name input field
  - Added warning message component for discovery failures
  - Added visual feedback (checkmark) for service name synchronization
  - Enhanced form validation to require service name for compose domains


# Before

<img width="754" height="861" alt="image" src="https://github.com/user-attachments/assets/3ada37f7-55ec-4c97-8e9a-bc12f2f4f199" />

# After

<img width="754" height="861" alt="image" src="https://github.com/user-attachments/assets/9949b4a0-2929-4629-bda8-2279b99510b1" />


# Video Demo

https://github.com/user-attachments/assets/3a6915f3-80c0-459c-a75c-215cc547dad2

Fixes #6 
