### PR TITLE
Fix OCI runtime exec failed error when

### DIFF
--- a/apps/dokploy/server/wss/docker-container-terminal.ts
+++ b/apps/dokploy/server/wss/docker-container-terminal.ts
@@ -1,5 +1,11 @@
 import type http from "node:http";
-import { findServerById, validateRequest } from "@dokploy/server";
+import {
+	execAsync,
+	execAsyncRemote,
+	findServerById,
+	getContainerWorkingDir,
+	validateRequest,
+} from "@dokploy/server";
 import { spawn } from "node-pty";
 import { Client } from "ssh2";
 import { WebSocketServer } from "ws";
@@ -44,6 +50,36 @@ export const setupDockerContainerTerminalWebSocketServer = (
 			return;
 		}
 		try {
+			// Get working directory for the container
+			const workingDir = await getContainerWorkingDir(
+				containerId,
+				serverId || null,
+			);
+
+			// Determine which shell to use, with fallback to sh if bash is not available
+			let shellToUse = activeWay || "bash";
+			
+			// If bash is requested, try to verify it exists, otherwise fallback to sh
+			if (shellToUse === "bash") {
+				try {
+					const checkCommand = `docker exec ${containerId} which bash 2>/dev/null || echo "not_found"`;
+					let checkResult;
+					
+					if (serverId) {
+						checkResult = await execAsyncRemote(serverId, checkCommand);
+					} else {
+						checkResult = await execAsync(checkCommand);
+					}
+					
+					if (checkResult.stdout.trim() === "not_found" || !checkResult.stdout.trim()) {
+						shellToUse = "sh";
+					}
+				} catch (_error) {
+					// If check fails, fallback to sh as it's more universally available
+					shellToUse = "sh";
+				}
+			}
+
 			if (serverId) {
 				const server = await findServerById(serverId);
 				if (!server.sshKeyId)
@@ -55,7 +91,7 @@ export const setupDockerContainerTerminalWebSocketServer = (
 				conn
 					.once("ready", () => {
 						conn.exec(
-							`docker exec -it ${containerId} ${activeWay}`,
+							`docker exec -w "${workingDir}" -it ${containerId} ${shellToUse}`,
 							{ pty: true },
 							(err, stream) => {
 								if (err) throw err;
@@ -107,7 +143,7 @@ export const setupDockerContainerTerminalWebSocketServer = (
 				const shell = getShell();
 				const ptyProcess = spawn(
 					shell,
-					["-c", `docker exec -it ${containerId} ${activeWay}`],
+					["-c", `docker exec -w "${workingDir}" -it ${containerId} ${shellToUse}`],
 					{},
 				);
 

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -101,6 +101,40 @@ export const getConfig = async (
 	} catch (_error) {}
 };
 
+export const getContainerWorkingDir = async (
+	containerId: string,
+	serverId?: string | null,
+): Promise<string> => {
+	try {
+		const command = `docker inspect ${containerId} --format '{{.Config.WorkingDir}}'`;
+		let stdout = "";
+
+		if (serverId) {
+			const result = await execAsyncRemote(serverId, command);
+			stdout = result.stdout.trim();
+		} else {
+			const result = await execAsync(command);
+			stdout = result.stdout.trim();
+		}
+
+		// Return working directory if set and not empty, otherwise use default
+		if (stdout && stdout !== "") {
+			return stdout;
+		}
+
+		// Fallback to root directory (always exists)
+		return "/";
+	} catch (error) {
+		// Log error but return fallback to keep terminal/commands functional
+		console.error(
+			`Failed to get working directory for container ${containerId}:`,
+			error,
+		);
+		// Fallback to root directory (always exists)
+		return "/";
+	}
+};
+
 export const getContainersByAppNameMatch = async (
 	appName: string,
 	appType?: "stack" | "docker-compose",

--- a/packages/server/src/utils/schedules/utils.ts
+++ b/packages/server/src/utils/schedules/utils.ts
@@ -4,6 +4,7 @@ import { paths } from "@dokploy/server/constants";
 import type { Schedule } from "@dokploy/server/db/schema/schedule";
 import { createDeploymentSchedule } from "@dokploy/server/services/deployment";
 import { updateDeploymentStatus } from "@dokploy/server/services/deployment";
+import { getContainerWorkingDir } from "@dokploy/server/services/docker";
 import { findScheduleById } from "@dokploy/server/services/schedule";
 import { scheduleJob as scheduleJobNode, scheduledJobs } from "node-schedule";
 import { getComposeContainer, getServiceContainer } from "../docker/utils";
@@ -58,14 +59,17 @@ export const runCommand = async (scheduleId: string) => {
 			serverId = compose.serverId || "";
 		}
 
+		// Get working directory for the container
+		const workingDir = await getContainerWorkingDir(containerId, serverId || null);
+
 		if (serverId) {
 			try {
 				await execAsyncRemote(
 					serverId,
 					`
 					set -e
-					echo "Running command: docker exec ${containerId} ${shellType} -c '${command}'" >> ${deployment.logPath};
-					docker exec ${containerId} ${shellType} -c '${command}' >> ${deployment.logPath} 2>> ${deployment.logPath} || { 
+					echo "Running command: docker exec -w "${workingDir}" ${containerId} ${shellType} -c '${command}'" >> ${deployment.logPath};
+					docker exec -w "${workingDir}" ${containerId} ${shellType} -c '${command}' >> ${deployment.logPath} 2>> ${deployment.logPath} || { 
 						echo "❌ Command failed" >> ${deployment.logPath};
 						exit 1;
 					}
@@ -81,11 +85,11 @@ export const runCommand = async (scheduleId: string) => {
 
 			try {
 				writeStream.write(
-					`docker exec ${containerId} ${shellType} -c ${command}\n`,
+					`docker exec -w ${workingDir} ${containerId} ${shellType} -c ${command}\n`,
 				);
 				await spawnAsync(
 					"docker",
-					["exec", containerId, shellType, "-c", command],
+					["exec", "-w", workingDir, containerId, shellType, "-c", command],
 					(data) => {
 						if (writeStream.writable) {
 							writeStream.write(data);


### PR DESCRIPTION
This pull request resolves an issue that users were running into when running Docker containers with mounted volumes. Terminal connections to that container would fail, commands wouldn't execute, and the following error would be seen:

`OCI runtime exec failed: exec failed: unable to start container process`

## Changes Made

- Added `getContainerWorkingDir()` utility function to retrieve container working directories
- Updated terminal WebSocket handler to include working directory flag in docker exec commands
- Added automatic shell detection (bash → sh fallback) for Alpine and minimal containers
- Updated scheduled command execution to use working directory flag

### Before

<img width="721" height="348" alt="image" src="https://github.com/user-attachments/assets/235ff823-0f38-43a0-b275-3a5305d3fe8c" />


### After

<img width="738" height="390" alt="image" src="https://github.com/user-attachments/assets/969ec027-12f1-4a27-aa58-706daf397c79" />


## Video Demo


https://github.com/user-attachments/assets/9a326d81-abc0-4724-b45c-99bfbd162b25

Fixes #27