### PR TITLE
Add name field to user profile form.

### DIFF
--- a/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
+++ b/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
@@ -32,6 +32,7 @@ import { Disable2FA } from "./disable-2fa";
 import { Enable2FA } from "./enable-2fa";
 
 const profileSchema = z.object({
+	name: z.string().optional(),
 	email: z.string(),
 	password: z.string().nullable(),
 	currentPassword: z.string().nullable(),
@@ -79,6 +80,7 @@ export const ProfileForm = () => {
 
 	const form = useForm<Profile>({
 		defaultValues: {
+			name: data?.user?.name || "",
 			email: data?.user?.email || "",
 			password: "",
 			image: data?.user?.image || "",
@@ -92,6 +94,7 @@ export const ProfileForm = () => {
 		if (data) {
 			form.reset(
 				{
+					name: data?.user?.name || "",
 					email: data?.user?.email || "",
 					password: form.getValues("password") || "",
 					image: data?.user?.image || "",
@@ -114,6 +117,7 @@ export const ProfileForm = () => {
 
 	const onSubmit = async (values: Profile) => {
 		await mutateAsync({
+			name: values.name || undefined,
 			email: values.email.toLowerCase(),
 			password: values.password || undefined,
 			image: values.image,
@@ -124,6 +128,7 @@ export const ProfileForm = () => {
 				await refetch();
 				toast.success("Profile Updated");
 				form.reset({
+					name: values.name,
 					email: values.email,
 					password: "",
 					image: values.image,
@@ -177,6 +182,23 @@ export const ProfileForm = () => {
 															<Input
 																placeholder={t("settings.profile.email")}
 																{...field}
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											<FormField
+												control={form.control}
+												name="name"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Name</FormLabel>
+														<FormControl>
+															<Input
+																placeholder="Name"
+																{...field}
+																value={field.value || ""}
 															/>
 														</FormControl>
 														<FormMessage />

--- a/apps/dokploy/components/layouts/user-nav.tsx
+++ b/apps/dokploy/components/layouts/user-nav.tsx
@@ -46,10 +46,16 @@ export const UserNav = () => {
 							src={data?.user?.image || ""}
 							alt={data?.user?.image || ""}
 						/>
-						<AvatarFallback className="rounded-lg">CN</AvatarFallback>
+						<AvatarFallback className="rounded-lg">
+							{data?.user?.name
+								? data.user.name.slice(0, 2).toUpperCase()
+								: "AC"}
+						</AvatarFallback>
 					</Avatar>
 					<div className="grid flex-1 text-left text-sm leading-tight">
-						<span className="truncate font-semibold">Account</span>
+						<span className="truncate font-semibold">
+							{data?.user?.name || "Account"}
+						</span>
 						<span className="truncate text-xs">{data?.user?.email}</span>
 					</div>
 					<ChevronsUpDown className="ml-auto size-4" />


### PR DESCRIPTION
# Add Name Field to User Profile Settings

This PR adds the ability for users to set and update their display name in their profile settings. The name field was already present in the database schema but was not exposed in the UI. This change completes the user profile feature by allowing users to personalize their identity across the application.

## Changes Made

### Frontend (`profile-form.tsx`)

- Added name field to the Zod validation schema (line 35)
- Added name to form default values and data synchronization (lines 83, 97)
- Added Name input field to the profile form UI (lines 191-207)
- Included name in form submission handler (lines 120, 131)

### Sidebar Display (`user-nav.tsx`)
- Updated sidebar to display user's name instead of hardcoded "Account" label (lines 56-58)
- Updated avatar fallback to show user's name initials instead of "CN" (lines 49-52)

## Before

<img width="972" height="395" alt="image" src="https://github.com/user-attachments/assets/240456cb-25a9-48b6-96a9-feefb4d02ea1" />

<img width="312" height="77" alt="image" src="https://github.com/user-attachments/assets/959b3149-22b5-4f11-9ae2-d67526057aeb" />

## After

<img width="1021" height="472" alt="image" src="https://github.com/user-attachments/assets/c1badeb8-e517-4bea-87ee-97671e6235df" />

<img width="299" height="73" alt="image" src="https://github.com/user-attachments/assets/8f0bced2-0d71-4b48-891b-549915cc732f" />

## Video Demo


https://github.com/user-attachments/assets/c8f416c2-fe1d-4653-ba25-9f43977bbfe5

Fixes #9 
